### PR TITLE
Adding in a bit more info to the query page

### DIFF
--- a/db/migrations/10000000000002_add_more_data_to_sql_statements.cr
+++ b/db/migrations/10000000000002_add_more_data_to_sql_statements.cr
@@ -1,0 +1,13 @@
+class AddMoreDataToSqlStatements::V10000000000002 < Avram::Migrator::Migration::V1
+  def migrate
+    alter table_for(BreezeSqlStatement) do
+      add elapsed_text : String, fill_existing_with: "N/A"
+    end
+  end
+
+  def rollback
+    alter table_for(BreezeSqlStatement) do
+      remove :elapsed_text
+    end
+  end
+end

--- a/src/breeze/actions/mixins/action_helpers.cr
+++ b/src/breeze/actions/mixins/action_helpers.cr
@@ -4,7 +4,7 @@ module Breeze::ActionHelpers
     after store_breeze_response
 
     Avram::Events::QueryEvent.subscribe do |event, duration|
-      if Breeze.settings.enabled
+      next unless Breeze.settings.enabled
         # TODO: move this to a config setting
         next if event.query.includes?("breeze_") || event.query.includes?("information_schema")
 

--- a/src/breeze/actions/mixins/action_helpers.cr
+++ b/src/breeze/actions/mixins/action_helpers.cr
@@ -3,15 +3,19 @@ module Breeze::ActionHelpers
     before store_breeze_request
     after store_breeze_response
 
-    Avram::Events::QueryEvent.subscribe do |event|
-      unless event.query.includes?("breeze_") || event.query.includes?("information_schema")
+    Avram::Events::QueryEvent.subscribe do |event, duration|
+      if Breeze.settings.enabled
+        # TODO: move this to a config setting
+        next if event.query.includes?("breeze_") || event.query.includes?("information_schema")
+
         req = Fiber.current.breeze_request
         spawn do
           SaveBreezeSqlStatement.create!(
             breeze_request_id: req.try(&.id),
             statement: event.query,
             args: event.args,
-            model: event.queryable
+            model: event.queryable,
+            elapsed_text: duration.to_elapsed_text
           )
         end
       end

--- a/src/breeze/actions/mixins/action_helpers.cr
+++ b/src/breeze/actions/mixins/action_helpers.cr
@@ -5,19 +5,18 @@ module Breeze::ActionHelpers
 
     Avram::Events::QueryEvent.subscribe do |event, duration|
       next unless Breeze.settings.enabled
-        # TODO: move this to a config setting
-        next if event.query.includes?("breeze_") || event.query.includes?("information_schema")
+      # TODO: move this to a config setting
+      next if event.query.includes?("breeze_") || event.query.includes?("information_schema")
 
-        req = Fiber.current.breeze_request
-        spawn do
-          SaveBreezeSqlStatement.create!(
-            breeze_request_id: req.try(&.id),
-            statement: event.query,
-            args: event.args,
-            model: event.queryable,
-            elapsed_text: duration.to_elapsed_text
-          )
-        end
+      req = Fiber.current.breeze_request
+      spawn do
+        SaveBreezeSqlStatement.create!(
+          breeze_request_id: req.try(&.id),
+          statement: event.query,
+          args: event.args,
+          model: event.queryable,
+          elapsed_text: duration.to_elapsed_text
+        )
       end
     end
   end

--- a/src/breeze/models/breeze_sql_statement.cr
+++ b/src/breeze/models/breeze_sql_statement.cr
@@ -3,6 +3,7 @@ class BreezeSqlStatement < BreezeBaseModel
     column statement : String
     column args : String?
     column model : String?
+    column elapsed_text : String
     belongs_to breeze_request : BreezeRequest?
   end
 end

--- a/src/breeze/pages/queries/show_page.cr
+++ b/src/breeze/pages/queries/show_page.cr
@@ -12,6 +12,9 @@ class Breeze::Queries::ShowPage < BreezeLayout
         list: ->{
           mount Breeze::DescriptionListRow, "Statement", breeze_sql_statement.statement
           mount Breeze::DescriptionListRow, "Args", breeze_sql_statement.args || "[]"
+          mount Breeze::DescriptionListRow, "Model", breeze_sql_statement.model || "Unknown"
+          mount Breeze::DescriptionListRow, "Elasped Time", breeze_sql_statement.elapsed_text
+          mount Breeze::DescriptionListRow, "Query executed", "#{time_ago_in_words(breeze_sql_statement.created_at)} ago"
         }
     end
   end

--- a/src/breeze/pages/requests/show_page.cr
+++ b/src/breeze/pages/requests/show_page.cr
@@ -47,7 +47,7 @@ class Breeze::Requests::ShowPage < BreezeLayout
           list: ->{
             if req.breeze_sql_statements.any?
               req.breeze_sql_statements.each do |query|
-                mount Breeze::DescriptionListRow, "#{query.model}Query", query.statement
+                render_query_row(query)
               end
             else
               para "No queries", class: "text-center text-gray-500 px-10 py-8 max-x-sm"
@@ -99,6 +99,26 @@ class Breeze::Requests::ShowPage < BreezeLayout
     req.breeze_response.try do |resp|
       resp.headers.as_h.each do |key, value|
         mount Breeze::DescriptionListRow, "Header #{key}", value[0].as_s
+      end
+    end
+  end
+
+  def render_query_row(query : BreezeSqlStatement)
+    link_styles = "block sm:border-t sm:border-gray-200 hover:bg-indigo-50 focus:outline-none focus:bg-gray-50 transition duration-150 ease-in-out"
+
+    link to: Queries::Show.with(query.id), class: link_styles do
+      div class: "flex items-center px-4 py-4 sm:px-4" do
+        div class: "min-w-0 flex-1 flex items-center" do
+          div class: "min-w-0 flex-1 px-4 sm:grid grid-cols-3 md:grid-cols-3 gap-4" do
+            div class: "text-sm leading-5 font-medium text-gray-500" { text "#{query.model}Query" }
+            div class: "text-sm leading-5 text-gray-500 col-span-2 mt-2 sm:mt-0" do
+              text query.statement
+            end
+          end
+        end
+        div do
+          mount RowArrow
+        end
       end
     end
   end

--- a/src/charms/time.cr
+++ b/src/charms/time.cr
@@ -1,0 +1,17 @@
+struct Time::Span
+  # Returns the total elapsed time as a printable String
+  # limited to minutes as this will be called mainly on
+  # Pulsar::TimedEvent durations
+  def to_elapsed_text : String
+    minutes = total_minutes
+    return "#{minutes.round(2)}m" if minutes >= 1
+
+    seconds = total_seconds
+    return "#{seconds.round(2)}s" if seconds >= 1
+
+    millis = total_milliseconds
+    return "#{millis.round(2)}ms" if millis >= 1
+
+    "#{(millis * 1000).round(2)}µs"
+  end
+end


### PR DESCRIPTION
Fixes #8

This PR updates the Query details page to add a bit more information. Before this, you still had to look at your log file to see how long a query took. Since we're using a `Pulsar::TimedEvent` for the query event stuff, we can just pull the info straight from there. 

The other thing this fixes is Breeze wasn't being disabled properly (at all) for the SqlStatement stuff, so those were being logged even in "production".

Also in #8, I wanted to add in something for a query `EXPLAIN`, but I think before I do that, we need to properly think out how that will work. If a query takes a LONG time to run, we will want the explain to happen asynchronously so you're not blocked. I'll open a new issue to track that feature.


### A few screenshots

Request Queries Before:
<img width="881" alt="Screen Shot 2021-03-09 at 3 05 06 PM" src="https://user-images.githubusercontent.com/2391/110550771-1e5bcc80-80e9-11eb-91d5-25fdb4cb501e.png">

Request Queries After:
<img width="955" alt="Screen Shot 2021-03-09 at 3 01 19 PM" src="https://user-images.githubusercontent.com/2391/110550781-27e53480-80e9-11eb-9988-60746b4bce30.png">


Query Details Before:
<img width="1252" alt="Screen Shot 2021-03-09 at 3 04 36 PM" src="https://user-images.githubusercontent.com/2391/110550814-35022380-80e9-11eb-8844-889f5e802f04.png">

Query Details After:
<img width="1259" alt="Screen Shot 2021-03-09 at 3 01 09 PM" src="https://user-images.githubusercontent.com/2391/110550829-3d5a5e80-80e9-11eb-94b4-e1fa059eefd5.png">
