### PR TITLE
Add new setting to skip storing BreezeRequest and BreezeResponse

### DIFF
--- a/src/breeze.cr
+++ b/src/breeze.cr
@@ -23,5 +23,6 @@ module Breeze
   Habitat.create do
     setting database : Avram::Database.class, example: "AppDatabase"
     setting enabled : Bool, example: "Lucky::Env.development?"
+    setting skip_breeze_if : Proc(HTTP::Server::Context, Bool)?
   end
 end

--- a/src/breeze.cr
+++ b/src/breeze.cr
@@ -23,6 +23,5 @@ module Breeze
   Habitat.create do
     setting database : Avram::Database.class, example: "AppDatabase"
     setting enabled : Bool, example: "Lucky::Env.development?"
-    setting skip_breeze_if : Proc(HTTP::Server::Context, Bool)?
   end
 end

--- a/src/breeze/actions/mixins/action_helpers.cr
+++ b/src/breeze/actions/mixins/action_helpers.cr
@@ -22,7 +22,7 @@ module Breeze::ActionHelpers
   end
 
   private def store_breeze_request
-    if Breeze.settings.enabled
+    if allow_breeze(context)
       req = SaveBreezeRequest.create!(
         path: request.resource,
         method: request.method,
@@ -40,7 +40,7 @@ module Breeze::ActionHelpers
   end
 
   private def store_breeze_response
-    if Breeze.settings.enabled
+    if allow_breeze(context)
       req = Fiber.current.breeze_request.not_nil!
       # TODO: can we run this in a spawn?
       SaveBreezeResponse.create!(
@@ -52,5 +52,10 @@ module Breeze::ActionHelpers
     end
 
     continue
+  end
+
+  private def allow_breeze(context : HTTP::Server::Context)
+    should_skip = Breeze.settings.skip_breeze_if.try(&.call(context))
+    Breeze.settings.enabled && !should_skip
   end
 end

--- a/src/breeze/actions/mixins/action_helpers.cr
+++ b/src/breeze/actions/mixins/action_helpers.cr
@@ -1,4 +1,8 @@
 module Breeze::ActionHelpers
+  Habitat.create do
+    setting skip_pipes_if : Proc(HTTP::Server::Context, Bool)?
+  end
+
   macro included
     before store_breeze_request
     after store_breeze_response
@@ -55,7 +59,7 @@ module Breeze::ActionHelpers
   end
 
   private def allow_breeze(context : HTTP::Server::Context)
-    should_skip = Breeze.settings.skip_breeze_if.try(&.call(context))
+    should_skip = settings.skip_pipes_if.try(&.call(context))
     Breeze.settings.enabled && !should_skip
   end
 end

--- a/tasks/breeze/generators/templates/breeze_config.ecr
+++ b/tasks/breeze/generators/templates/breeze_config.ecr
@@ -6,4 +6,10 @@ Breeze.configure do |settings|
 
   # Enable Breeze only for this environment
   settings.enabled = Lucky::Env.development?
+
+  # Add this setting in if you want to skip the breeze pipes
+  # for specific calls.
+  # settings.skip_breeze_if = ->(context : HTTP::Server::Context) {
+  #   context.request.resource.starts_with?("/admin")
+  # }
 end

--- a/tasks/breeze/generators/templates/breeze_config.ecr
+++ b/tasks/breeze/generators/templates/breeze_config.ecr
@@ -1,15 +1,19 @@
 # https://github.com/luckyframework/breeze
-#
+
+# Configuration settings for Breeze
 Breeze.configure do |settings|
   # The database to store the request info
   settings.database = AppDatabase
 
   # Enable Breeze only for this environment
   settings.enabled = Lucky::Env.development?
+end
 
-  # Add this setting in if you want to skip the breeze pipes
+# Configuration settings for Actions
+Breeze::ActionHelpers.configure do |settings|
+  # Add this setting in if you want to skip the breeze before/after pipes
   # for specific calls.
-  # settings.skip_breeze_if = ->(context : HTTP::Server::Context) {
+  # settings.skip_pipes_if = ->(context : HTTP::Server::Context) {
   #   context.request.resource.starts_with?("/admin")
   # }
 end


### PR DESCRIPTION
Fixes #9

This gives you a configuration option so you can skip storing the request and response to breeze based on whatever you want. Works similar to how our LogHandler works.

One thing to note, in #9 I was getting a TON of requests to /favicon.ico. This was because 1. we didn't have a favicon, and 2. we're using the `fallback` action for SPA. Normal assets don't get logged to Breeze already. But if you use the `fallback` action, and any asset is missing, it'll hit the fallback which does get logged. I'd imagine this will be more of an edge case, and people may be more inclined to ignore things like `/admin` or whatever.

Also note that I can't skip the SqlStatement logging. Since that doesn't happen at the instance level, that's at the class level of `Lucky::Action` so there's no `context` method available. 