### PR TITLE
Adds new task that allows you to truncate all of the breeze data

### DIFF
--- a/src/breeze.cr
+++ b/src/breeze.cr
@@ -4,6 +4,7 @@ require "lucky"
 require "./charms/*"
 require "./breeze/models/*"
 require "./breeze/operations/*"
+require "./breeze/queries/mixins/*"
 require "./breeze/queries/*"
 require "./breeze/actions/mixins/*"
 

--- a/src/breeze/queries/breeze_pipe_query.cr
+++ b/src/breeze/queries/breeze_pipe_query.cr
@@ -1,2 +1,3 @@
 class BreezePipeQuery < BreezePipe::BaseQuery
+  include Breeze::Queries::Resetable
 end

--- a/src/breeze/queries/breeze_request_query.cr
+++ b/src/breeze/queries/breeze_request_query.cr
@@ -1,2 +1,3 @@
 class BreezeRequestQuery < BreezeRequest::BaseQuery
+  include Breeze::Queries::Resetable
 end

--- a/src/breeze/queries/breeze_response_query.cr
+++ b/src/breeze/queries/breeze_response_query.cr
@@ -1,2 +1,3 @@
 class BreezeResponseQuery < BreezeResponse::BaseQuery
+  include Breeze::Queries::Resetable
 end

--- a/src/breeze/queries/breeze_sql_statement_query.cr
+++ b/src/breeze/queries/breeze_sql_statement_query.cr
@@ -1,2 +1,3 @@
 class BreezeSqlStatementQuery < BreezeSqlStatement::BaseQuery
+  include Breeze::Queries::Resetable
 end

--- a/src/breeze/queries/mixins/resetable.cr
+++ b/src/breeze/queries/mixins/resetable.cr
@@ -1,0 +1,2 @@
+module Breeze::Queries::Resetable
+end

--- a/tasks/breeze/data/reset.cr
+++ b/tasks/breeze/data/reset.cr
@@ -1,0 +1,22 @@
+require "colorize"
+
+class Breeze::Data::Reset < LuckyCli::Task
+  summary "Deletes all of the Breeze data"
+
+  def call
+    table_names = [] of String
+    {% for type in Breeze::Queries::Resetable.includers %}
+      table_names << {{ type }}.new.table_name.to_s
+    {% end %}
+
+    table_names = table_names.join(", ")
+    statement = <<-SQL
+    TRUNCATE TABLE #{table_names} RESTART IDENTITY CASCADE;
+    SQL
+
+    output.puts "Truncating tables #{table_names.colorize(:green)}"
+
+    Breeze.settings.database.exec statement
+    puts "done."
+  end
+end


### PR DESCRIPTION
Fixes #7

This PR adds a new task `lucky breeze.data.reset` that will truncate all of the breeze tables resetting their IDs all back to 1. 

Sort of related: https://github.com/luckyframework/avram/issues/648

I was originally just going to iterate over the query classes, and call `truncate` on each of them, but because of foreign key constraints, that didn't work. 

I forgot to add my screenshot of what this looks like 😂 
<img width="1073" alt="Screen Shot 2021-03-12 at 1 50 29 PM" src="https://user-images.githubusercontent.com/2391/111006301-6d03a380-8341-11eb-9175-9793a3217c13.png">
