### PR TITLE
First pass at extension registration

### DIFF
--- a/src/breeze.cr
+++ b/src/breeze.cr
@@ -2,6 +2,7 @@ require "pulsar"
 require "avram"
 require "lucky"
 require "./charms/*"
+require "./breeze/extension"
 require "./breeze/models/*"
 require "./breeze/operations/*"
 require "./breeze/queries/mixins/*"
@@ -20,9 +21,14 @@ require "./breeze/pages/**"
 
 module Breeze
   VERSION = "0.1.0"
+  class_getter extensions = [] of Breeze::Extension
 
   Habitat.create do
     setting database : Avram::Database.class, example: "AppDatabase"
     setting enabled : Bool, example: "Lucky::Env.development?"
+  end
+
+  def self.register(extension : Breeze::Extension)
+    extensions << extension
   end
 end

--- a/src/breeze/components/breeze/navbar_links.cr
+++ b/src/breeze/components/breeze/navbar_links.cr
@@ -1,24 +1,15 @@
 class Breeze::NavbarLinks < Breeze::BreezeComponent
   needs context : HTTP::Server::Context
 
-  Habitat.create do
-    setting links : Array(Proc(Breeze::NavbarLinks, Nil)) = [
-      ->(navbar : Breeze::NavbarLinks) {
-        navbar.mount_link("Requests", to: Breeze::Requests::Index)
-      },
-      ->(navbar : Breeze::NavbarLinks) {
-        navbar.mount_link("Queries", to: Breeze::Queries::Index)
-      },
-    ]
-  end
-
   def render
-    settings.links.each do |component|
-      component.call(self)
+    mount_link("Requests", to: Breeze::Requests::Index)
+    mount_link("Queries", to: Breeze::Queries::Index)
+    Breeze.extensions.each do |extension|
+      mount_link(extension.name, to: extension.entrypoint)
     end
   end
 
-  def mount_link(link_text : String, to action : Lucky::Action.class)
+  private def mount_link(link_text : String, to action : Lucky::Action.class)
     mount(Breeze::NavbarLink, context: context, link_text: link_text, link_to: action.path)
   end
 end

--- a/src/breeze/components/breeze/navbar_links.cr
+++ b/src/breeze/components/breeze/navbar_links.cr
@@ -5,9 +5,7 @@ class Breeze::NavbarLinks < Breeze::BreezeComponent
     mount_link("Requests", to: Breeze::Requests::Index)
     mount_link("Queries", to: Breeze::Queries::Index)
     Breeze.extensions.each do |extension|
-      extension.navbar_link(context)
-        .view(view)
-        .render
+      mount extension.navbar_link(context)
     end
   end
 

--- a/src/breeze/components/breeze/navbar_links.cr
+++ b/src/breeze/components/breeze/navbar_links.cr
@@ -5,7 +5,9 @@ class Breeze::NavbarLinks < Breeze::BreezeComponent
     mount_link("Requests", to: Breeze::Requests::Index)
     mount_link("Queries", to: Breeze::Queries::Index)
     Breeze.extensions.each do |extension|
-      mount_link(extension.name, to: extension.entrypoint)
+      extension.navbar_link(context)
+        .view(view)
+        .render
     end
   end
 

--- a/src/breeze/components/breeze_component.cr
+++ b/src/breeze/components/breeze_component.cr
@@ -1,4 +1,28 @@
 abstract class Breeze::BreezeComponent < Lucky::BaseComponent
   include Lucky::UrlHelpers
   alias HtmlProc = Proc(IO::Memory) | Proc(Nil)
+
+  def mount(component : Lucky::BaseComponent, *args, **named_args) : Nil
+    print_component_comment(component) do
+      component.view(view).render
+    end
+  end
+
+  def mount(component : Lucky::BaseComponent, *args, **named_args) : Nil
+    print_component_comment(component) do
+      component.view(view).render do |*yield_args|
+        yield *yield_args
+      end
+    end
+  end
+
+  private def print_component_comment(component : Lucky::BaseComponent) : Nil
+    if Lucky::HTMLPage.settings.render_component_comments
+      raw "<!-- BEGIN: #{component.class.name} #{component.class.file_location} -->"
+      yield
+      raw "<!-- END: #{component.class.name} -->"
+    else
+      yield
+    end
+  end
 end

--- a/src/breeze/components/breeze_component.cr
+++ b/src/breeze/components/breeze_component.cr
@@ -17,11 +17,7 @@ abstract class Breeze::BreezeComponent < Lucky::BaseComponent
   end
 
   private def print_component_comment(component : Lucky::BaseComponent) : Nil
-    if Lucky::HTMLPage.settings.render_component_comments
-      raw "<!-- BEGIN: #{component.class.name} #{component.class.file_location} -->"
-      yield
-      raw "<!-- END: #{component.class.name} -->"
-    else
+    print_component_comment(component.class) do
       yield
     end
   end

--- a/src/breeze/extension.cr
+++ b/src/breeze/extension.cr
@@ -5,12 +5,8 @@
 # module BreezeCustom
 #   extend Breeze::Extension
 #
-#   def self.name : String
-#     "Custom"
-#   end
-#
-#   def self.entrypoint : Lucky::Action.class
-#     BreezeCustom::Index
+#   def self.navbar_link(context : HTTP::Server::Context) : Breeze::NavbarLink
+#     Breeze::NavbarLink.new(context: context, link_text: "Custom", link_to: BreezeCustom::Index.path)
 #   end
 # end
 # ```
@@ -22,11 +18,5 @@
 # ```
 #
 module Breeze::Extension
-  # The name of the extension
-  # Will be used as the text in the link found in the navbar
-  abstract def name : String
-
-  # The entrypoint of the extension
-  # Will be used as the href of the navbar link
-  abstract def entrypoint : Lucky::Action.class
+  abstract def navbar_link(context : HTTP::Server::Context) : Breeze::NavbarLink
 end

--- a/src/breeze/extension.cr
+++ b/src/breeze/extension.cr
@@ -1,0 +1,32 @@
+# To create an extension you must extend this module
+#
+# Example:
+# ```
+# module BreezeCustom
+#   extend Breeze::Extension
+#
+#   def self.name : String
+#     "Custom"
+#   end
+#
+#   def self.entrypoint : Lucky::Action.class
+#     BreezeCustom::Index
+#   end
+# end
+# ```
+#
+# Projects that want to use this extension will need to register it
+#
+# ```
+# Breeze.register BreezeCustom
+# ```
+#
+module Breeze::Extension
+  # The name of the extension
+  # Will be used as the text in the link found in the navbar
+  abstract def name : String
+
+  # The entrypoint of the extension
+  # Will be used as the href of the navbar link
+  abstract def entrypoint : Lucky::Action.class
+end

--- a/src/extensions/breeze_carbon.cr
+++ b/src/extensions/breeze_carbon.cr
@@ -5,11 +5,17 @@ require "../breeze_carbon/actions/**"
 require "../breeze_carbon/pages/**"
 
 module BreezeCarbon
+  extend Breeze::Extension
+
   Habitat.create do
     setting email_previews : Carbon::EmailPreviews.class, example: "Emails::Previews"
   end
-end
 
-Breeze::NavbarLinks.settings.links << ->(navbar : Breeze::NavbarLinks) {
-  navbar.mount_link("Emails", to: BreezeCarbon::Emails::Index)
-}
+  def self.name : String
+    "Emails"
+  end
+
+  def self.entrypoint : Lucky::Action.class
+    BreezeCarbon::Emails::Index
+  end
+end

--- a/src/extensions/breeze_carbon.cr
+++ b/src/extensions/breeze_carbon.cr
@@ -11,11 +11,11 @@ module BreezeCarbon
     setting email_previews : Carbon::EmailPreviews.class, example: "Emails::Previews"
   end
 
-  def self.name : String
-    "Emails"
-  end
-
-  def self.entrypoint : Lucky::Action.class
-    BreezeCarbon::Emails::Index
+  def self.navbar_link(context : HTTP::Server::Context) : Breeze::NavbarLink
+    Breeze::NavbarLink.new(
+      context: context,
+      link_text: "Emails",
+      link_to: BreezeCarbon::Emails::Index.path
+    )
   end
 end

--- a/tasks/breeze/generators/templates/breeze_config.ecr
+++ b/tasks/breeze/generators/templates/breeze_config.ecr
@@ -16,6 +16,7 @@ end
   #
   # settings.email_previews = Emails::Previews
 # end
+# Breeze.register BreezeCarbon
 
 # Configuration settings for Actions
 Breeze::ActionHelpers.configure do |settings|


### PR DESCRIPTION
Rather than using habitat to integrate extensions into Breeze, this adds a registration process.

It's quite simple right now as we only need to do one thing, create the navbar links. We ask for two pieces of info:
- name
- entrypoint

