### PR TITLE
Fix current_page? check

### DIFF
--- a/src/breeze/components/breeze/navbar_link.cr
+++ b/src/breeze/components/breeze/navbar_link.cr
@@ -9,7 +9,7 @@ class Breeze::NavbarLink < Breeze::BreezeComponent
 
   def link_styles
     extra_classes =
-      if current_page?(context.request.path)
+      if current_page?(link_to)
         link_active_class
       else
         link_inactive_class


### PR DESCRIPTION
`current_page?` checks the passed in string against the context's request that it has access to. By passing in the request path, it was always returning true

https://github.com/luckyframework/lucky/blob/3e0fdd29f034db190e94b23a02ef0f2ed5146f39/src/lucky/page_helpers/url_helpers.cr#L31