### PR TITLE
Replace procs with slot pattern

### DIFF
--- a/src/breeze/components/breeze/description_list.cr
+++ b/src/breeze/components/breeze/description_list.cr
@@ -1,26 +1,32 @@
 # https://tailwindui.com/components/application-ui/data-display/description-lists#component-e1b5917b21bbe76a73a96c5ca876225f
 class Breeze::DescriptionList < Breeze::BreezeComponent
-  needs heading_title : HtmlProc
-  needs list : HtmlProc
-
   def render
-    render_main_heading
-    render_list
+    slots = Slots.new
+    yield slots
+    render_main_heading(slots.heading_title)
+    render_list(slots.list)
   end
 
-  def render_main_heading
+  def render_main_heading(heading_title)
     div class: "px-4 py-5 border-b border-gray-200 sm:px-6" do
       h3 class: "text-lg leading-6 font-medium text-gray-900" do
-        heading_title.call
+        heading_title.try(&.call)
       end
     end
   end
 
-  def render_list
+  def render_list(list)
     div class: "px-4 py-5 sm:p-0" do
       dl do
-        list.call
+        list.try(&.call)
       end
     end
+  end
+
+  class Slots
+    include Breeze::Slottable
+
+    has_one :heading_title
+    has_one :list
   end
 end

--- a/src/breeze/components/breeze_component.cr
+++ b/src/breeze/components/breeze_component.cr
@@ -1,6 +1,5 @@
 abstract class Breeze::BreezeComponent < Lucky::BaseComponent
   include Lucky::UrlHelpers
-  alias HtmlProc = Proc(IO::Memory) | Proc(Nil)
 
   def mount(component : Lucky::BaseComponent, *args, **named_args) : Nil
     print_component_comment(component) do

--- a/src/breeze/components/slottable.cr
+++ b/src/breeze/components/slottable.cr
@@ -1,0 +1,17 @@
+module Breeze::Slottable
+  macro has_one(name)
+    property {{ name.id }} : Proc(Nil)?
+
+    def {{ name.id }}(&block)
+      @{{ name.id }} = block
+    end
+  end
+
+  macro has_many(name)
+    property {{ name.id }} = [] of Proc(Nil)
+
+    def {{ name.id }}(&block)
+      @{{ name.id }} << block
+    end
+  end
+end

--- a/src/breeze/pages/queries/show_page.cr
+++ b/src/breeze/pages/queries/show_page.cr
@@ -7,15 +7,18 @@ class Breeze::Queries::ShowPage < Breeze::BreezeLayout
 
   def content
     mount Breeze::Panel do
-      mount Breeze::DescriptionList,
-        heading_title: ->{ text "Query details" },
-        list: ->{
+      mount Breeze::DescriptionList do |c|
+        c.heading_title do
+          text "Query details"
+        end
+        c.list do
           mount Breeze::DescriptionListRow, "Statement", breeze_sql_statement.statement
           mount Breeze::DescriptionListRow, "Args", breeze_sql_statement.args || "[]"
           mount Breeze::DescriptionListRow, "Model", breeze_sql_statement.model || "Unknown"
           mount Breeze::DescriptionListRow, "Elasped Time", breeze_sql_statement.elapsed_text
           mount Breeze::DescriptionListRow, "Query executed", "#{time_ago_in_words(breeze_sql_statement.created_at)} ago"
-        }
+        end
+      end
     end
   end
 end

--- a/src/breeze/pages/requests/show_page.cr
+++ b/src/breeze/pages/requests/show_page.cr
@@ -17,34 +17,40 @@ class Breeze::Requests::ShowPage < Breeze::BreezeLayout
   def content
     div class: "w-2/3" do
       mount Breeze::Panel do
-        mount Breeze::DescriptionList,
-          heading_title: ->{
+        mount Breeze::DescriptionList do |c|
+          c.heading_title do
             mount Breeze::Badge, req, large: true
             span class: "ml-3 font-normal text-base text-blue-800" do
               text "about #{time_ago_in_words(req.created_at)} ago"
             end
-          },
-          list: ->{
+          end
+          c.list do
             mount Breeze::DescriptionListRow, "Action", req.action
             req.breeze_response.try do |resp|
               mount Breeze::DescriptionListRow, "Response Status", "#{resp.status} #{Wordsmith::Inflector.humanize(HTTP::Status.from_value?(resp.status))}"
             end
             mount Breeze::DescriptionListRow, "Request Body", req.body || "No body"
             mount Breeze::DescriptionListRow, "Request Params", req.parsed_params.to_s || "No params"
-          }
+          end
+        end
       end
       mount Breeze::Panel do
-        mount Breeze::DescriptionList,
-          heading_title: ->{ text "Session" },
-          list: ->{
+        mount Breeze::DescriptionList do |c|
+          c.heading_title do
+            text "Session"
+          end
+          c.list do
             render_session_info
-          }
+          end
+        end
       end
 
       mount Breeze::Panel do
-        mount Breeze::DescriptionList,
-          heading_title: ->{ text "Queries" },
-          list: ->{
+        mount Breeze::DescriptionList do |c|
+          c.heading_title do
+            text "Queries"
+          end
+          c.list do
             if req.breeze_sql_statements.any?
               req.breeze_sql_statements.each do |query|
                 render_query_row(query)
@@ -52,33 +58,43 @@ class Breeze::Requests::ShowPage < Breeze::BreezeLayout
             else
               para "No queries", class: "text-center text-gray-500 px-10 py-8 max-x-sm"
             end
-          }
+          end
+        end
       end
 
       mount Breeze::Panel do
-        mount Breeze::DescriptionList,
-          heading_title: ->{ text "Pipes" },
-          list: ->{
+        mount Breeze::DescriptionList do |c|
+          c.heading_title do
+            text "Pipes"
+          end
+          c.list do
             req.breeze_pipes.each do |pipe|
               mount Breeze::DescriptionListRow, "Foo", pipe.name
             end
-          }
+          end
+        end
       end
 
       mount Breeze::Panel do
-        mount Breeze::DescriptionList,
-          heading_title: ->{ text "Request Headers" },
-          list: ->{
+        mount Breeze::DescriptionList do |c|
+          c.heading_title do
+            text "Request Headers"
+          end
+          c.list do
             render_request_header_info
-          }
+          end
+        end
       end
 
       mount Breeze::Panel do
-        mount Breeze::DescriptionList,
-          heading_title: ->{ text "Response Headers" },
-          list: ->{
+        mount Breeze::DescriptionList do |c|
+          c.heading_title do
+            text "Response Headers"
+          end
+          c.list do
             render_response_header_info
-          }
+          end
+        end
       end
     end
   end

--- a/src/breeze_carbon/pages/emails/show_page.cr
+++ b/src/breeze_carbon/pages/emails/show_page.cr
@@ -9,16 +9,19 @@ class BreezeCarbon::Emails::ShowPage < Breeze::BreezeLayout
 
   def content
     mount Breeze::Panel do
-      mount Breeze::DescriptionList,
-        heading_title: ->{ text "Email Previews" },
-        list: ->{
+      mount Breeze::DescriptionList do |c|
+        c.heading_title do
+          text "Email Previews"
+        end
+        c.list do
           mount Breeze::DescriptionListRow, "Subject", email.subject
           mount Breeze::DescriptionListRow, "From", email.from.address
           mount Breeze::DescriptionListRow, "To", email.to.join(", ", &.address)
           email.headers.each do |key, value|
             mount Breeze::DescriptionListRow, key, value
           end
-        }
+        end
+      end
     end
     mount Breeze::Panel do
       div class: "px-4 py-5 border-b border-gray-200 sm:px-6" do


### PR DESCRIPTION
Consider this a sandbox for experimenting with slottable components.

This is inspired by Rails' [view_component](https://viewcomponent.org/#passing-content-to-viewcomponents) though I think they delegate the slots to sub-components which I haven't entirely wrapped my head around.

Pros:
- More explicit (Procs work and in this PR use less lines, but it was discovered to work, not implemented to)
- More flexible (the has_many macro allows to make nicer lists even though it could be achieved with needing an array of procs)

Cons:
- I don't see a way to make it as "first-class" as view_component's. You still have to "new" up a class and yield it
- Type safety (at least in this implementation there's no way to make slots required or fail to compile)