### PR TITLE
Updating shard versions. 

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,18 +11,18 @@ license: MIT
 dependencies:
   lucky:
     github: luckyframework/lucky
-    version: ~> 0.26.0
+    version: ">= 0.26.0"
   avram:
     github: luckyframework/avram
-    version: ~> 0.19.0
+    version: ">= 0.19.0"
   pulsar:
     github: luckyframework/pulsar
-    version: ~> 0.2.0
+    version: ">= 0.2.0"
+  lucky_task:
+    github: luckyframework/lucky_task
+    version: ">= 0.1.0"
 
 development_dependencies:
-  lucky_cli:
-    github: luckyframework/lucky_cli
-    version: ~> 0.26.0
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.13.4
+    version: "~> 0.14.2"

--- a/src/breeze/pages/requests/show_page.cr
+++ b/src/breeze/pages/requests/show_page.cr
@@ -44,7 +44,7 @@ class Breeze::Requests::ShowPage < Breeze::BreezeLayout
       mount Breeze::DescriptionList,
         heading_title: ->{ text "Queries" },
         list: ->{
-          if req.breeze_sql_statements.any?
+          if !req.breeze_sql_statements.empty?
             req.breeze_sql_statements.each do |query|
               render_query_row(query)
             end

--- a/tasks.cr
+++ b/tasks.cr
@@ -6,6 +6,8 @@
 # LuckyCli::Runner.run
 # ```
 
+require "lucky_task"
+
 # Require all of the built-in Breeze tasks
 require "./tasks/**"
 

--- a/tasks/breeze/data/reset.cr
+++ b/tasks/breeze/data/reset.cr
@@ -1,6 +1,6 @@
 require "colorize"
 
-class Breeze::Data::Reset < LuckyCli::Task
+class Breeze::Data::Reset < LuckyTask::Task
   summary "Deletes all of the Breeze data"
 
   def call

--- a/tasks/breeze/install.cr
+++ b/tasks/breeze/install.cr
@@ -1,7 +1,7 @@
 require "colorize"
 require "./generators/*"
 
-class Breeze::Install < LuckyCli::Task
+class Breeze::Install < LuckyTask::Task
   summary "Installs the required files for running Breeze"
 
   def call


### PR DESCRIPTION
Fixing the tasks to be compatible with LuckyTask.

I'm not sure if we need to lock this in to a specific Lucky version or not. Currently I have this installed on one of my apps, but I can't update to Lucky 0.27 because this is locked to 0.26. Breeze should work fine on both from what I can tell.