### PR TITLE
Refactoring the email preview setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,44 +87,44 @@ Breeze comes with a [Carbon](https://github.com/luckyframework/carbon) extension
 
 1. Add the require to your `src/shards.cr` right below your `require "breeze"`:
 
-    ```crystal
-   require "breeze"
-   require "breeze/extensions/carbon"
-   ```
+  ```crystal
+  require "breeze"
+  require "breeze/extensions/breeze_carbon"
+  ```
 
 2. Add your Email preview class to `src/emails/previews.cr`:
 
-   ```crystal
-   class Emails::Previews < Carbon::EmailPreviews
-     def previews : Hash(String, Carbon::Email)
-       {
-         "welcome_email"  => WelcomeEmail.new(UserQuery.first),
-         "password_reset" => PasswordResetRequestEmail.new(UserQuery.first),
-       } of String => Carbon::Email
-     end
-   end
-   ```
+  ```crystal
+  class Emails::Previews < Carbon::EmailPreviews
+    def previews : Array(Carbon::Email)
+      [
+        WelcomeEmail.new(UserQuery.first),
+        PasswordResetRequestEmail.new(UserQuery.first),
+      ] of Carbon::Email
+    end
+  end
+  ```
 
-3. Update your Breeze config in `config/breeze.cr`:
+3. Add the `BreezeCarbon` config to `config/breeze.cr`:
 
-   ```crystal
-   Breeze.configure do |settings|
-     # ... other settings
-     
-     # Set this to the name of your preview class
-     settings.email_previews = Emails::Previews
-   end
-   ```
-   
+  ```crystal
+  BreezeCarbon.configure do |settings|
+
+    # Set this to the name of your preview class
+    settings.email_previews = Emails::Previews
+  end
+  Breeze.register BreezeCarbon
+  ```
+
 ### Usage
 
 Just visit `/breeze/emails` in your browser, and you'll see your emails. Click the `HTML` button to see the HTML version of your email, or the `TEXT` to see the plain text version.
 
 ### Configuration
 
-By enabling this extension, Breeze will require a new setting `email_previews` which is the class that will contain your preview setup. This is so Breeze knows what you named the class.
+`BreezeCarbon` requires setting the `email_previews` setting to the name of your email preview class.
+Your email preview class should inherit from `Carbon::EmailPreviews`, and define an instance method `previews` which returns an `Array(Carbon::Email)`.
 
-Your email preview class should inherit from `Carbon::EmailPreviews`, and define an instance method `previews` which returns a `Hash(String, Carbon::Email)`. The `String` key is a key that will be passed through the URL to locate which email Breeze will display. The value will be an instance of the `Carbon::Email` to be rendered. Since each email requires different arguments in order to be instantiated, it's up to you to define how those values are set.
 
 ## Extending Breeze
 

--- a/src/breeze_carbon/email_previews.cr
+++ b/src/breeze_carbon/email_previews.cr
@@ -1,10 +1,14 @@
+require "wordsmith"
+
 # TODO: Move this in to Carbon directly
 abstract class Carbon::EmailPreviews
-  alias EmailLookup = Hash(String, Carbon::Email)
-
-  abstract def previews : EmailLookup
+  abstract def previews : Array(Carbon::Email)
 
   def self.find(key : String) : Carbon::Email
-    self.new.previews[key]? || raise "No Carbon::Email found with the key #{key}. Be sure to add it to your `previews` method"
+    email = self.new.previews.find do |carbon|
+      carbon.class.name == key
+    end
+
+    email || raise "No Carbon::Email found with the key #{key}. Be sure to add it to your `previews` method"
   end
 end

--- a/src/breeze_carbon/email_previews.cr
+++ b/src/breeze_carbon/email_previews.cr
@@ -1,5 +1,3 @@
-require "wordsmith"
-
 # TODO: Move this in to Carbon directly
 abstract class Carbon::EmailPreviews
   abstract def previews : Array(Carbon::Email)

--- a/src/breeze_carbon/pages/emails/index_page.cr
+++ b/src/breeze_carbon/pages/emails/index_page.cr
@@ -1,5 +1,5 @@
 class BreezeCarbon::Emails::IndexPage < Breeze::BreezeLayout
-  needs emails : Carbon::EmailPreviews::EmailLookup
+  needs emails : Array(Carbon::Email)
 
   def page_title : String
     "All Emails"
@@ -15,14 +15,14 @@ class BreezeCarbon::Emails::IndexPage < Breeze::BreezeLayout
         h2 "Preview Emails", class: "text-xl"
       end
       ul class: "mt-1 divide-y divide-gray-200" do
-        emails.each do |key, email|
-          email_row(key, email)
+        emails.each do |email|
+          email_row(email)
         end
       end
     end
   end
 
-  def email_row(key : String, email : Carbon::Email)
+  def email_row(email : Carbon::Email)
     li do
       div class: "flex items-center px-4 py-4 sm:px-4" do
         div class: "min-w-0 flex-1 flex items-center" do
@@ -33,12 +33,16 @@ class BreezeCarbon::Emails::IndexPage < Breeze::BreezeLayout
           end
         end
         div do
-          link "HTML", to: Emails::Show.with(key, plain_format: false), class: format_button_styles
+          link "HTML", to: Emails::Show.with(slug_for_email(email), plain_format: false), class: format_button_styles
           nbsp
-          link "TEXT", to: Emails::Show.with(key, plain_format: true), class: format_button_styles
+          link "TEXT", to: Emails::Show.with(slug_for_email(email), plain_format: true), class: format_button_styles
         end
       end
     end
+  end
+
+  private def slug_for_email(email : Carbon::Email) : String
+    email.class.name
   end
 
   private def format_button_styles : String


### PR DESCRIPTION
Ref #23

The idea of setting up a Hash was so you could define a key to pass through the URL. This could be problematic though because you might do "Reset Password" which isn't URI safe. By getting rid of the key, we can turn this in to an Array making the setup a lot easier. This is essentially what we do with the server middleware.

Also updated the README with better install instructions for the extension.