### PR TITLE
Adding new spec helpers file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Breeze is a development dashboard for [Lucky Framework](https://luckyframework.o
        github: luckyframework/breeze
    ```
 
-1. Run `shards install`
-1. Add the require to your `src/shards.cr`:
+2. Run `shards install`
+3. Add the require to your `src/shards.cr`:
 
    ```crystal
    require "avram"
@@ -40,7 +40,7 @@ Breeze is a development dashboard for [Lucky Framework](https://luckyframework.o
    require "breeze"
    ```
 
-1. Add the tasks to your `tasks.cr`:
+4. Add the tasks to your `tasks.cr`:
 
   ```crystal
   # ...
@@ -51,7 +51,7 @@ Breeze is a development dashboard for [Lucky Framework](https://luckyframework.o
   LuckyTask::Runner.run
   ```
 
-1. Add the spec helpers to your `spec/spec_helper.cr`:
+5. Add the spec helpers to your `spec/spec_helper.cr`:
 
   ```crystal
   require "spec"
@@ -63,9 +63,9 @@ Breeze is a development dashboard for [Lucky Framework](https://luckyframework.o
   require "./setup/**"
   ```
 
-1. Run `lucky breeze.install`
+6. Run `lucky breeze.install`
 
-1. Run `lucky db.migrate`
+7. Run `lucky db.migrate`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Breeze is a development dashboard for [Lucky Framework](https://luckyframework.o
        github: luckyframework/breeze
    ```
 
-2. Run `shards install`
-3. Add the require to your `src/shards.cr`:
+1. Run `shards install`
+1. Add the require to your `src/shards.cr`:
 
    ```crystal
    require "avram"
@@ -40,7 +40,7 @@ Breeze is a development dashboard for [Lucky Framework](https://luckyframework.o
    require "breeze"
    ```
 
-4. Add the tasks to your `tasks.cr`:
+1. Add the tasks to your `tasks.cr`:
 
   ```crystal
   # ...
@@ -51,9 +51,21 @@ Breeze is a development dashboard for [Lucky Framework](https://luckyframework.o
   LuckyTask::Runner.run
   ```
 
-5. Run `lucky breeze.install`
+1. Add the spec helpers to your `spec/spec_helper.cr`:
 
-6. Run `lucky db.migrate`
+  ```crystal
+  require "spec"
+  require "lucky_flow"
+  require "../src/app"
+  # ...
+  require "breeze/spec_helpers"
+
+  require "./setup/**"
+  ```
+
+1. Run `lucky breeze.install`
+
+1. Run `lucky db.migrate`
 
 ## Usage
 

--- a/src/spec_helpers.cr
+++ b/src/spec_helpers.cr
@@ -1,0 +1,4 @@
+# Use this file to require any code required
+# for applications with Breeze to run specs
+
+require "../db/migrations/**"


### PR DESCRIPTION
Fixes #21

The file right now just requires the migrations. This is a required step in order to run specs with an app that's using Breeze. 

Without this step, you'll get the following error:

```
❯ crystal spec


Finished in 281.44 milliseconds
0 examples, 0 failures, 0 errors, 0 pending
Unhandled exception: Breeze::BreezePipe wants to use the 'breeze_pipes' table but it is missing.

If you need to create the 'breeze_pipes' table...

  ▸ Generate a migration:

      lucky gen.migration CreateBreeze::BreezePipes
```

Which could be confusing for someone new to Lucky. You currently have to add `require "breeze/db/migrations/**"` which is fine, but we may want to add other additional helper stuff later. Now we have a file we can add additional things to. 