### PR TITLE
Implement elapsed_text display for request/response

### DIFF
--- a/db/migrations/10000000000004_add_elapsed_time_to_response.cr
+++ b/db/migrations/10000000000004_add_elapsed_time_to_response.cr
@@ -1,0 +1,13 @@
+class AddElapsedTimeToResponse::V20210710193748 < Avram::Migrator::Migration::V1
+  def migrate
+    alter table_for(BreezeResponse) do
+      add elapsed_text : String, fill_existing_with: "N/A"
+    end
+  end
+
+  def rollback
+    alter table_for(BreezeResponse) do
+      remove :elapsed_text
+    end
+  end
+end

--- a/src/breeze/models/breeze_response.cr
+++ b/src/breeze/models/breeze_response.cr
@@ -3,6 +3,7 @@ class Breeze::BreezeResponse < Breeze::BreezeBaseModel
     column status : Int32
     column session : JSON::Any
     column headers : JSON::Any
+    column elapsed_text : String
     belongs_to breeze_request : BreezeRequest
   end
 end

--- a/src/breeze/pages/requests/show_page.cr
+++ b/src/breeze/pages/requests/show_page.cr
@@ -27,6 +27,7 @@ class Breeze::Requests::ShowPage < Breeze::BreezeLayout
           mount Breeze::DescriptionListRow, "Action", req.action
           req.breeze_response.try do |resp|
             mount Breeze::DescriptionListRow, "Response Status", "#{resp.status} #{Wordsmith::Inflector.humanize(HTTP::Status.from_value?(resp.status))}"
+            mount Breeze::DescriptionListRow, "Response Elapsed Time", resp.elapsed_text
           end
           mount Breeze::DescriptionListRow, "Request Body", req.body || "No body"
           mount Breeze::DescriptionListRow, "Request Params", req.parsed_params.to_s || "No params"

--- a/src/charms/fiber.cr
+++ b/src/charms/fiber.cr
@@ -3,4 +3,5 @@ class Fiber
   # This is stored in the Fiber so other stuff can access it.
   # For example, we can associate queries and pipes with the request
   property breeze_request : Breeze::BreezeRequest?
+  property breeze_request_start : Time::Span?
 end


### PR DESCRIPTION
Adds the elapsed_text field to the breeze_response model.

Should address the feature request in #33.
