### PR TITLE
don't install dev deps on postinstall

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -13,7 +13,7 @@ targets:
     main: src/precompiled_tasks/breeze_install.cr
 
 scripts:
-  postinstall: shards build
+  postinstall: shards build --without-development
 
 executables:
   - lucky.breeze.install


### PR DESCRIPTION
Related: https://github.com/luckyframework/lucky/issues/1524

Unlike the other shards, this one doesn't have a precompile script, but it does run `shards build` on postinstall just like it. We don't need to install ameba when Breeze is a dependency, so we can just skip it.