### PR TITLE
Lock to Crystal 1.4 or later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.0.0
-          - 1.1.0
-          - 1.2.0
-          - 1.3.0
+          - latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
@@ -34,10 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.0.0
-          - 1.1.0
-          - 1.2.0
-          - 1.3.0
+          - 1.4.0
+          - latest
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.2.0
 authors:
   - Jeremy Woertink <jeremywoertink@gmail.com>
 
-crystal: ">= 1.0.0"
+crystal: ">= 1.4.0"
 
 license: MIT
 
@@ -15,27 +15,24 @@ targets:
 scripts:
   postinstall: shards build --without-development
 
-executables:
-  - lucky.breeze.install
-
 dependencies:
   lucky:
     github: luckyframework/lucky
-    version: ">= 0.28.0"
+    version: ">= 0.30.1"
   avram:
     github: luckyframework/avram
-    version: ">= 0.21.0"
+    version: ">= 0.23.0"
   pulsar:
     github: luckyframework/pulsar
-    version: ">= 0.2.0"
+    version: ">= 0.2.3"
   lucky_task:
     github: luckyframework/lucky_task
-    version: ">= 0.1.0"
+    version: ">= 0.1.1"
 
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: "~> 0.14.2"
+    version: "~> 1.0.0"
   lucky_cli:
     github: luckyframework/lucky_cli
-    version: ">= 0.28.0"
+    version: ">= 0.30.0"


### PR DESCRIPTION
# Purpose

Locks Lucky to Crystal version 1.4.0 or later.
# Description

With the release of the new Crystal book being focused on 1.4.0, and shards like Ameba locking to that version, as well as Crystal 1.5.0 is slated to come out in the next 2 months, it makes sense that we start pushing to have everyone use a later version of Crystal. This will also allow us to clean up some code with the assumption that the user is using 1.4.0 or later.
